### PR TITLE
Fix settings panel alignment

### DIFF
--- a/src/lib/components/Controls/Settings/index.svelte
+++ b/src/lib/components/Controls/Settings/index.svelte
@@ -64,9 +64,12 @@
     border-radius: 50%;
     aspect-ratio: 4/4;
   }
+  #settings-box {
+    position: relative;
+  }
   .settings-box {
     position: absolute;
-    left: 0;
+    right: 0;
     top: 70px;
     height: 58vh;
     padding: 5px 20px;


### PR DESCRIPTION
## Summary
- ensure settings dropdown aligns to the right of the controls

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6843ed6069f48321b72e9bd8eff29ebd