### PR TITLE
Fix asset paths for production

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -26,7 +26,7 @@
     position: relative;
     overflow: hidden;
     background-color: black;
-    background-image: url("/assets/background/bg1.jpg");
+    background-image: url("assets/background/bg1.jpg");
     background-repeat: no-repeat;
     background-size: cover;
     background-position: center;

--- a/src/lib/components/Controls/CampFire/index.svelte
+++ b/src/lib/components/Controls/CampFire/index.svelte
@@ -4,7 +4,7 @@
 
   export let volume: number;
 
-  let fire = new Audio("/assets/engine/effects/fire.mp3");
+  let fire = new Audio("assets/engine/effects/fire.mp3");
   let isFire = false;
 
   function toggleStorm() {

--- a/src/lib/components/Controls/Jungle/index.svelte
+++ b/src/lib/components/Controls/Jungle/index.svelte
@@ -4,7 +4,7 @@
 
   export let volume: number;
 
-  let jungle = new Audio("/assets/engine/effects/jungle.mp3");
+  let jungle = new Audio("assets/engine/effects/jungle.mp3");
   let isActive = false;
 
   function toggleSound() {

--- a/src/lib/components/Controls/Rain/index.svelte
+++ b/src/lib/components/Controls/Rain/index.svelte
@@ -5,7 +5,7 @@
 
   export let volume: number;
 
-  let rain = new Audio("/assets/engine/effects/rain.mp3");
+  let rain = new Audio("assets/engine/effects/rain.mp3");
   let isRaining = false;
 
   function toggleRain() {

--- a/src/lib/components/Controls/Settings/Background.svelte
+++ b/src/lib/components/Controls/Settings/Background.svelte
@@ -4,7 +4,7 @@
   // get id from localstorage
   let id: any = localStorage.getItem("bg-id") || 1;
   const bg = document.getElementById("bg");
-  bg.style.backgroundImage = `url('/assets/background/bg${id}.jpg')`;
+  bg.style.backgroundImage = `url('assets/background/bg${id}.jpg')`;
 
   function nextBg() {
     if (id < 10) {
@@ -13,7 +13,7 @@
     } else {
       id = 1;
     }
-    bg.style.backgroundImage = `url('/assets/background/bg${id}.jpg')`;
+    bg.style.backgroundImage = `url('assets/background/bg${id}.jpg')`;
     localStorage.setItem("bg-id", id.toString());
   }
 
@@ -24,7 +24,7 @@
     } else {
       id = 10;
     }
-    bg.style.backgroundImage = `url('/assets/background/bg${id}.jpg')`;
+    bg.style.backgroundImage = `url('assets/background/bg${id}.jpg')`;
     localStorage.setItem("bg-id", id.toString());
   }
 
@@ -47,7 +47,7 @@
     <button on:click={prevBg}>
       <IconArrowLeft size={20} />
     </button>
-    <img id="bg-preview" src="/assets/background/bg{id}.jpg" alt="" />
+    <img id="bg-preview" src="assets/background/bg{id}.jpg" alt="" />
     <button on:click={nextBg}>
       <IconArrowRight size={20} />
     </button>

--- a/src/lib/components/Controls/Thunder/index.svelte
+++ b/src/lib/components/Controls/Thunder/index.svelte
@@ -4,7 +4,7 @@
 
   export let volume: number;
 
-  let storm = new Audio("/assets/engine/effects/thunder.mp3");
+  let storm = new Audio("assets/engine/effects/thunder.mp3");
   let isStorming = false;
 
   function toggleStorm() {

--- a/src/lib/components/TopBar/TopBar.svelte
+++ b/src/lib/components/TopBar/TopBar.svelte
@@ -22,7 +22,7 @@
     <MacControls />
   {/if}
   <div class="drag" data-tauri-drag-region>
-    <img src="/assets/dots.svg" alt="logo" width="18" />
+    <img src="assets/dots.svg" alt="logo" width="18" />
   </div>
   {#if currentOs !== "mac"}
     <WindowsLinuxControls />

--- a/src/lib/components/TrackList/TrackListItem.svelte
+++ b/src/lib/components/TrackList/TrackListItem.svelte
@@ -43,7 +43,7 @@
   }
 
   function playTrack() {
-    const audio = new Audio(`/assets/engine/tracks/${track.track}`);
+    const audio = new Audio(`assets/engine/tracks/${track.track}`);
     audio.volume = volume;
     audio.play();
     audio.loop = true;
@@ -90,7 +90,7 @@
   <div class={"carousel__item-body " + (track.isPlaying ? "playing" : "")}>
     <img
       class="carousel__item-body__img"
-      src="/assets/images/{track.id}.jpg"
+      src="assets/images/{track.id}.jpg"
       alt=""
     />
     <div>

--- a/src/lib/components/TrackList/index.svelte
+++ b/src/lib/components/TrackList/index.svelte
@@ -83,7 +83,7 @@
         tracks[i - 1].isPlaying = !tracks[i - 1].isPlaying;
         if (tracks[i - 1].isPlaying) {
           const audio = new Audio(
-            `/assets/engine/tracks/${tracks[i - 1].track}`
+            `assets/engine/tracks/${tracks[i - 1].track}`
           );
           audio.play();
           audio.loop = true;

--- a/src/lib/engine/Drums/Hat.ts
+++ b/src/lib/engine/Drums/Hat.ts
@@ -1,6 +1,6 @@
 import * as Tone from 'tone';
 
-const samplePath = `/assets/engine/DrumSamples/hat.mp3`;
+const samplePath = `assets/engine/DrumSamples/hat.mp3`;
 const samples = {C4: samplePath};
 
 const lpf = new Tone.Filter(2400, "lowpass");

--- a/src/lib/engine/Drums/Kick.ts
+++ b/src/lib/engine/Drums/Kick.ts
@@ -1,6 +1,6 @@
 import * as Tone from 'tone';
 
-const samplePath = `/assets/engine/DrumSamples/kick.mp3`;
+const samplePath = `assets/engine/DrumSamples/kick.mp3`;
 const samples = {C4: samplePath};
 
 const vol = new Tone.Volume(-3);

--- a/src/lib/engine/Drums/Snare.ts
+++ b/src/lib/engine/Drums/Snare.ts
@@ -1,6 +1,6 @@
 import * as Tone from 'tone';
 
-const samplePath = `/assets/engine/DrumSamples/snare.mp3`;
+const samplePath = `assets/engine/DrumSamples/snare.mp3`;
 const samples = {C4: samplePath};
 
 const lpf = new Tone.Filter(6000, "lowpass");

--- a/src/lib/engine/Piano/Samples.ts
+++ b/src/lib/engine/Piano/Samples.ts
@@ -1,6 +1,6 @@
 const letters = ["A","C","D#","F#"];
 const octaves = [1, 2, 3, 4, 5, 6];
-const samplePath = `/assets/engine/PianoSamples/`;
+const samplePath = `assets/engine/PianoSamples/`;
 const velocity = 1;
 
 const notes = [];


### PR DESCRIPTION
## Summary
- use relative asset paths so audio and images load after building

## Testing
- `pnpm build`
- `pnpm check` *(fails: svelte-check found 10 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684403250bc88321ac5b433b1c3d671d